### PR TITLE
gkd350h port compatibility issue

### DIFF
--- a/sdl/video.cpp
+++ b/sdl/video.cpp
@@ -71,6 +71,7 @@ void S9xInitDisplay(int argc, char **argv) {
     ttf_font->add("C:\\Windows\\Fonts\\simsun.ttc");
 #else
     ttf_font->add("/usr/share/fonts/dejavu/DejaVuSansMono.ttf");
+    ttf_font->add("/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf");
     ttf_font->add("/usr/share/gmenunx/skins/Default/font.ttf");
 #endif
 


### PR DESCRIPTION
fix crash when snes9x.conf not exists  …
add menu hotkey(start+select) for gkd350h
add font path(fix 350h menu font render issue)
